### PR TITLE
add sub-packages to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,12 @@ setup(name="defcon",
     author_email="tal@typesupply.com",
     url="http://code.typesupply.com",
     license="MIT",
-    packages=["defcon"],
+    packages=[
+        "defcon",
+        "defcon.objects",
+        "defcon.pens",
+        "defcon.test",
+        "defcon.tools"
+    ],
     package_dir={"":"Lib"}
 )


### PR DESCRIPTION
Hi,

After I run `python setup.py install`,  I cannot `import defcon` properly. That's because only the root of the `defcon` package is being compiled and copied to site-packages, whereas the other subpackages ("objects", "pens", etc.) are not explicitly defined in the setup.py script.

All best,

Cosimo
