### PR TITLE
Typo correction

### DIFF
--- a/Lib/defcon/__init__.py
+++ b/Lib/defcon/__init__.py
@@ -39,7 +39,7 @@ def registerRepresentationFactory(cls, name, factory, destructiveNotifications=N
 
 def unregisterRepresentationFactory(cls, name):
     """
-    Unegister the representation factory stored under
+    Unregister the representation factory stored under
     **name** in all instances of **cls**.
     """
     del cls.representationFactories[name]

--- a/Lib/defcon/objects/contour.py
+++ b/Lib/defcon/objects/contour.py
@@ -262,7 +262,7 @@ class Contour(BaseObject):
         """
         Reverse the direction of the contour. It's important to note
         that the actual points stored in this object will be completely
-        repalced by new points.
+        replaced by new points.
 
         This will post *Contour.WindingDirectionChanged*,
         *Contour.PointsChanged* and *Contour.Changed* notifications.

--- a/Lib/defcon/tools/bezierMath.py
+++ b/Lib/defcon/tools/bezierMath.py
@@ -89,7 +89,7 @@ def joinSegments(onCoords1, offCoords1, offCoords2, onCoords2, offCoords3, offCo
         if abs(a1 - a2) < 0.05:
             smooth = True
 
-    # first calculate an aproximaly t
+    # first calculate an approximaly t
     d1 = _distance((on2X, on2Y), (off2X, off2Y))
     d2 = d1 + _distance((off3X, off3Y), (on2X, on2Y))
 

--- a/Lib/defcon/tools/notifications.py
+++ b/Lib/defcon/tools/notifications.py
@@ -54,7 +54,7 @@ class NotificationCenter(object):
         Add an observer to this notification dispatcher.
 
         * **observer** An object that can be referenced with weakref.
-        * **methodName** A string epresenting the method to be called
+        * **methodName** A string representing the method to be called
           when the notification is posted.
         * **notification** The notification that the observer should
           be notified of. If this is None, all notifications for


### PR DESCRIPTION
Hi, I'm RoboFont user and I'm using font libraries like defcon. I found a typo in docstrings while referencing defcon. So I fixed the typo but didn't read all the files, so I'm not sure if all the typos have been fixed.
I hope this will help you. :)