### PR TITLE
add glyphset so glyphs with components are also getting an proper area value

### DIFF
--- a/Lib/defcon/test/objects/test_glyph.py
+++ b/Lib/defcon/test/objects/test_glyph.py
@@ -609,6 +609,25 @@ class GlyphTest(unittest.TestCase):
         self.assertFalse(glyph.pointInside((350, 350)))
         self.assertFalse(glyph.pointInside((-100, -100)))
 
+    def test_area(self):
+        font = Font()
+
+        baseGlyph = font.newGlyph("baseGlyph")
+        pointPen = baseGlyph.getPointPen()
+        pointPen.beginPath()
+        pointPen.addPoint((0, 0), "move")
+        pointPen.addPoint((0, 100), "line")
+        pointPen.addPoint((100, 100), "line")
+        pointPen.addPoint((100, 0), "line")
+        pointPen.addPoint((0, 0), "line")
+        pointPen.endPath()
+        self.assertEqual(baseGlyph.area, 10000)
+
+        componentGlyph = font.newGlyph("componentGlyph")
+        pointPen = componentGlyph.getPointPen()
+        pointPen.addComponent("baseGlyph", [1, 0, 0, 1, 0, 0])
+        self.assertEqual(componentGlyph.area, 10000)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/defcon/tools/representations.py
+++ b/Lib/defcon/tools/representations.py
@@ -40,7 +40,7 @@ def _makeGlyphToGroupMapping(groups):
 # -----
 
 def glyphAreaRepresentationFactory(glyph):
-    pen = AreaPen()
+    pen = AreaPen(glyph.layer)
     glyph.draw(pen)
     return abs(pen.value)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-    - JOB: "2.7 32-bit"
-      PYTHON_HOME: "C:\\Python27"
 
     - JOB: "3.6 64-bit"
       PYTHON_HOME: "C:\\Python36-x64"


### PR DESCRIPTION

reported here https://forum.robofont.com/topic/788/rglyph-area-method-only-works-on-glyphs-with-contours/3