### PR TITLE
Fix component bounds updating when the base glyph changes

### DIFF
--- a/Lib/defcon/test/objects/test_component.py
+++ b/Lib/defcon/test/objects/test_component.py
@@ -64,6 +64,19 @@ class ComponentTest(unittest.TestCase):
         with self.assertRaises(AttributeError):
             self.component.layer = (0.0, 0.0, 350.0, 350.0)
 
+    def test_update_bounds(self):
+        font = Font(getTestFontPath())
+        a = font["A"]
+        self.assertEqual(a.bounds, (0, 0, 700, 700))
+        aacute = font.newGlyph('Aacute')
+        component = Component()
+        component.baseGlyph = 'A'
+        aacute.appendComponent(component)
+        self.assertEqual(aacute.bounds, (0, 0, 700, 700))
+        a.leftMargin = 100
+        self.assertEqual(a.bounds, (100, 0, 800, 700))
+        self.assertEqual(aacute.bounds, (100, 0, 800, 700))
+
     def test_controlPointBounds(self):
         self.font = Font(getTestFontPath())
         self.glyph = self.font["C"]


### PR DESCRIPTION
Hello, this is more of a bug report at the moment than a proper pull request as I'm just contributing a test case.

The problem in practice is: if you measure the bounds of a glyph that uses a component, then change the base glyph of that component, then measure the bounds of the glyph again, the bounds have not changed. They do not reflect the changes that have been happening to the base glyph.

I my code, I fixed that issue with this workaround, which clear the cached bounds.

```python
        for component in glyph.components:
            component._representations = {}
```

What would be a way to fix this problem that fits the defcon architecture?