### PR TITLE
Fix bw compatibility issue with font.ufoFormatVersion

### DIFF
--- a/Lib/defcon/objects/font.py
+++ b/Lib/defcon/objects/font.py
@@ -273,9 +273,24 @@ class Font(BaseObject):
     path = property(_get_path, _set_path, doc="The location of the file on disk. Setting the path should only be done when the user has moved the file in the OS interface. Setting the path is not the same as a save operation.")
 
     def _get_ufoFormatVersion(self):
+        import warnings
+
+        warnings.warn(
+            "The 'ufoFormatVersion' attribute is deprecated; use the 'ufoFormatVersionTuple'",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if self._ufoFormatVersion is None:
+            return None
+        else:
+            return self._ufoFormatVersion.major
+
+    ufoFormatVersion = property(_get_ufoFormatVersion, doc="The UFO format major version that will be used when saving. This is taken from a loaded UFO during __init__. If this font was not loaded from a UFO, this will return None until the font has been saved. Deprecated, use ufoFormatVersionTuple instead.")
+
+    def _get_ufoFormatVersionTuple(self):
         return self._ufoFormatVersion
 
-    ufoFormatVersion = property(_get_ufoFormatVersion, doc="The UFO format version that will be used when saving. This is taken from a loaded UFO during __init__. If this font was not loaded from a UFO, this will return None until the font has been saved.")
+    ufoFormatVersionTuple = property(_get_ufoFormatVersionTuple, doc="The UFO format (major, minor) version tuple that will be used when saving. This is taken from a loaded UFO during __init__. If this font was not loaded from a UFO, this will return None until the font has been saved.")
 
     def _get_ufoFileStructure(self):
         return self._ufoFileStructure

--- a/Lib/defcon/test/objects/test_font.py
+++ b/Lib/defcon/test/objects/test_font.py
@@ -538,12 +538,19 @@ class FontTest(unittest.TestCase):
             elif os.path.isdir(path):
                 shutil.rmtree(path)
 
+    def test_new_font_format(self):
+        font = Font()
+        self.assertEqual(font.ufoFormatVersion, None)
+        self.assertEqual(font.ufoFormatVersionTuple, None)
+
     def test_save_in_place_different_format(self):
         path = makeTestFontCopy()
         font = Font(path)
-        self.assertEqual(font._ufoFormatVersion, (3, 0))
+        self.assertEqual(font.ufoFormatVersion, 3)
+        self.assertEqual(font.ufoFormatVersionTuple, (3, 0))
         font.save(formatVersion=2)
-        self.assertEqual(font._ufoFormatVersion, (2, 0))
+        self.assertEqual(font.ufoFormatVersion, 2)
+        self.assertEqual(font.ufoFormatVersionTuple, (2, 0))
 
     def test_save_in_place_invalid_ufo(self):
         path = makeTestFontCopy()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-fonttools==4.9.0
+fonttools==4.10.0
 # git+https://github.com/typesupply/compositor

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-fonttools==4.10.0
+fonttools==4.10.2
 # git+https://github.com/typesupply/compositor

--- a/setup.py
+++ b/setup.py
@@ -159,11 +159,11 @@ setup_params = dict(
         'pytest>=3.0.3',
     ],
     install_requires=[
-        "fonttools[ufo,unicode] >= 3.31.0",
+        "fonttools[ufo,unicode] >= 4.10.0",
     ],
     extras_require={
         'pens': ["fontPens>=0.1.0"],
-        'lxml': ["fonttools[lxml] >= 3.31.0"],
+        'lxml': ["fonttools[lxml] >= 4.10.0"],
     },
     cmdclass={
         "release": release,


### PR DESCRIPTION
Add `font.ufoFormatVersionTuple` attribute and make `font.ufoFormatVersion` return the major format version again, but deprecate. As per discussion in #289.