### PR TITLE
Mark library as requiring Python 3.6+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -154,6 +154,7 @@ setup_params = dict(
     package_dir={"": "Lib"},
     packages=find_packages("Lib"),
     include_package_data=True,
+    python_requires=">=3.6",
     setup_requires=pytest_runner + sphinx + wheel + bump2version,
     tests_require=[
         'pytest>=3.0.3',


### PR DESCRIPTION
Python 2's pip tries to install it otherwise.