### PR TITLE
Travis-ci: added support for ppc64le build along with amd64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,23 @@ matrix:
   include:    
     - python: 3.6
       env: TOXENV=py36-cov
+      arch: amd64
     - python: 3.7
       env:
         - TOXENV=py37-cov
         - BUILD_DIST=true
+      arch: amd64
       # required to run python3.7 on Travis CI
       # https://github.com/travis-ci/travis-ci/issues/9815
+      dist: xenial
+    - python: 3.6
+      env: TOXENV=py36-cov
+      arch: ppc64le
+    - python: 3.7
+      env:
+        - TOXENV=py37-cov
+        - BUILD_DIST=true
+      arch: ppc64le
       dist: xenial
 install:
   - pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjay-cpu/defcon/builds/186088702 . I believe it is ready for the final review and merge.
Please have a look on it and if everything looks fine for you then please approve it for merge.

Thanks !!