### PR TITLE
Fix behavior in removeObserver.

### DIFF
--- a/Lib/defcon/test/tools/test_notifications.py
+++ b/Lib/defcon/test/tools/test_notifications.py
@@ -71,7 +71,7 @@ class NotificationCenterTest(unittest.TestCase):
         center.removeObserver(observer, "A", observable)
         self.assertFalse(center.hasObserver(observer, "A", observable))
 
-    def test_removeObserver_noNotification(self):
+    def test_removeObserver_allNotifications(self):
         center = NotificationCenter()
         observable1 = _TestObservable(center, "Observable1")
         observable2 = _TestObservable(center, "Observable2")
@@ -85,7 +85,7 @@ class NotificationCenterTest(unittest.TestCase):
         center.addObserver(observer1, "notificationCallback", "B", observable2)
         center.addObserver(observer2, "notificationCallback", "A", observable2)
         center.addObserver(observer2, "notificationCallback", "B", observable2)
-        center.removeObserver(observer1, None, observable1)
+        center.removeObserver(observer1, "all", observable1)
         self.assertFalse(center.hasObserver(observer1, "A", observable1))
         self.assertFalse(center.hasObserver(observer1, "B", observable1))
         self.assertTrue(center.hasObserver(observer1, "A", observable2))
@@ -108,8 +108,10 @@ class NotificationCenterTest(unittest.TestCase):
         observable = _TestObservable(center, "Observable")
         observer = NotificationTestObserver()
         center.addObserver(observer, "notificationCallback", None, observable)
+        center.addObserver(observer, "notificationCallback", "A", observable)
         center.removeObserver(observer, None, observable)
         self.assertFalse(center.hasObserver(observer, None, observable))
+        self.assertTrue(center.hasObserver(observer, "A", observable))
 
     def test_removeObserver_no_notification_no_observable(self):
         center = NotificationCenter()

--- a/Lib/defcon/tools/notifications.py
+++ b/Lib/defcon/tools/notifications.py
@@ -145,11 +145,14 @@ class NotificationCenter(object):
                 del self._registry[key][observer]
             if not len(self._registry[key]):
                 del self._registry[key]
-            self._observerKeyBacktrack[observer][observable].remove(key)
-            if not self._observerKeyBacktrack[observer][observable]:
-                del self._observerKeyBacktrack[observer][observable]
-            if not self._observerKeyBacktrack[observer]:
-                del self._observerKeyBacktrack[observer]
+            if observer in self._observerKeyBacktrack:
+                if observable in self._observerKeyBacktrack[observer]:
+                    if key in self._observerKeyBacktrack[observer][observable]:
+                        self._observerKeyBacktrack[observer][observable].remove(key)
+                    if not self._observerKeyBacktrack[observer][observable]:
+                        del self._observerKeyBacktrack[observer][observable]
+                if not self._observerKeyBacktrack[observer]:
+                    del self._observerKeyBacktrack[observer]
             if key in self._identifierRegistry:
                 if observer in self._identifierRegistry[key]:
                     del self._identifierRegistry[key][observer]

--- a/Lib/defcon/tools/notifications.py
+++ b/Lib/defcon/tools/notifications.py
@@ -84,6 +84,7 @@ class NotificationCenter(object):
         must accept a single *notification* argument. This will
         be a :class:`Notification` object.
         """
+        assert notification != "all", "'all' is a reserved name and can not be used as a notification."
         if observable is not None:
             observable = weakref.ref(observable)
         observer = weakref.ref(observer)


### PR DESCRIPTION
The change I made to allow `None` to indicate "please remove everything that observer is watching in observable" had a logic flaw.

- In `addObserver`, `notification=None` means "send every notification to this observer for this observable".
- In `removeObserver`, `notification` means "remove every registered notification from this observable for this observer".

Those seem alike, but this example shows my mistake:

```python
er = This()
able = That()

able.addObserver(observer=er, notification=None, method="anyNotificationHappened")
able.addObserver(observer=er, notification="specific", method="specificNotificationHappened")

able.removeObserver(observer=er, notification=None)
```

The `notification=None` has two conflicting meanings:

1. Remove the notification that will call method `er.anyNotificationHappened`.
2. Remove all observations for er.
    - `er.anyNotificationHappened`
    - `er.specificNotificationHappened`

Being able to vigorously remove observations without knowing specific notifications is useful, but the previous behavior is more important. So, I'm introducing an "all" option for `notification` to provide the new functionality without changing the old.