### PR TITLE
_version.py is auto-generated, should be git-ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ htmlcov
 
 # OS X Finder
 .DS_Store
+
+# auto-generated version file
+Lib/defcon/_version.py


### PR DESCRIPTION
otherwise it's listed among untracked files and it may accidentally be committed if one doesn't know that it should not be