### PR TITLE
Implementing .tempLib

### DIFF
--- a/Lib/defcon/objects/font.py
+++ b/Lib/defcon/objects/font.py
@@ -121,6 +121,7 @@ class Font(BaseObject):
         self._groups = None
         self._features = None
         self._lib = None
+        self._tempLib = None
         self._kerningGroupConversionRenameMaps = None
 
         self._layers = self.instantiateLayerSet()
@@ -599,6 +600,20 @@ class Font(BaseObject):
         return self._lib
 
     lib = property(_get_lib, doc="The font's :class:`Lib` object.")
+
+    # temp lib
+
+    def _get_tempLib(self):
+        if self._tempLib is None:
+            self._tempLib = self.instantiateLib()
+        return self._tempLib
+
+    def _set_tempLib(self, value):
+        if value is not None:
+            self.tempLib.clear()
+            self.tempLib.update(value)
+
+    tempLib = property(_get_tempLib, _set_tempLib, doc="The font's :class:`tempLib` object.")
 
     # images
 
@@ -1743,6 +1758,7 @@ class Font(BaseObject):
             ('kerning', serialized_get),
             ('layers',  serialized_get),
             ('lib', serialized_get),
+            ('tempLib', serialized_get),
             ('guidelines', serialized_list_get)
         )
 
@@ -1795,6 +1811,7 @@ class Font(BaseObject):
             ('kerning', single_update),
             ('layers', init_set_layers),
             ('lib', single_update),
+            ('tempLib', single_update),
             ('guidelines', set_guidelines)
         )
 

--- a/Lib/defcon/objects/glyph.py
+++ b/Lib/defcon/objects/glyph.py
@@ -130,6 +130,7 @@ class Glyph(BaseObject):
         self._anchors = []
         self._guidelines = []
         self._lib = None
+        self._tempLib = None
 
         if contourClass is None:
             contourClass = Contour
@@ -1098,6 +1099,20 @@ class Glyph(BaseObject):
         self._lib.removeObserver(observer=self, notification="Lib.Changed")
         self._lib.endSelfNotificationObservation()
 
+    # temp lib
+
+    def _get_tempLib(self):
+        if self._tempLib is None:
+            self._tempLib = self.instantiateLib()
+        return self._tempLib
+
+    def _set_tempLib(self, value):
+        if value is not None:
+            self.tempLib.clear()
+            self.tempLib.update(value)
+
+    tempLib = property(_get_tempLib, _set_tempLib, doc="The glyph's :class:`tempLib` object.")
+
     # -----
     # Image
     # -----
@@ -1354,7 +1369,8 @@ class Glyph(BaseObject):
             ('anchors', serialized_list_get),
             ('guidelines', serialized_list_get),
             ('image', serialized_get),
-            ('lib', serialized_get)
+            ('lib', serialized_get),
+            ('tempLib', serialized_get),
         ]
 
         if self._shallowLoadedContours is not None:
@@ -1396,10 +1412,11 @@ class Glyph(BaseObject):
         setters = (
             ('name', set_attr),
             ('unicodes', set_attr),
-            ('width',  set_attr),
-            ('height',  set_attr),
-            ('note',  set_attr),
-            ('lib',  set_attr),
+            ('width', set_attr),
+            ('height', set_attr),
+            ('note', set_attr),
+            ('lib', set_attr),
+            ('tempLib', set_attr),
             ('_shallowLoadedContours', set_attr),
             ('_contours', init_set(list_init, self.instantiateContour, set_each(self.appendContour, True))),
             ('components', init_set(list_init, self.instantiateComponent, set_each(self.appendComponent, True))),

--- a/Lib/defcon/objects/layer.py
+++ b/Lib/defcon/objects/layer.py
@@ -28,6 +28,7 @@ class Layer(BaseObject):
     - Layer.GlyphUnicodesChanged
     - Layer.NameChanged
     - Layer.ColorChanged
+    - Layer.LibChanged
 
     The Layer object has some dict like behavior. For example, to get a glyph::
 
@@ -83,6 +84,7 @@ class Layer(BaseObject):
 
         self._color = None
         self._lib = None
+        self._tempLib = None
         self._unicodeData = None
 
         self._directory = None
@@ -473,6 +475,20 @@ class Layer(BaseObject):
 
     lib = property(_get_lib, _set_lib, doc="The layer's :class:`Lib` object.")
 
+    # temp lib
+
+    def _get_tempLib(self):
+        if self._tempLib is None:
+            self._tempLib = self.instantiateLib()
+        return self._tempLib
+
+    def _set_tempLib(self, value):
+        if value is not None:
+            self.tempLib.clear()
+            self.tempLib.update(value)
+
+    tempLib = property(_get_tempLib, _set_tempLib, doc="The layer's :class:`tempLib` object.")
+
     # unicode data
 
     def instantiateUnicodeData(self):
@@ -716,6 +732,7 @@ class Layer(BaseObject):
 
         getters = (
             ('lib', serialized_get),
+            ('tempLib', serialized_get),
             ('color', simple_get),
             ('glyphs', lambda _: {name: self[name].getDataForSerialization() for name in self.keys()})
         )
@@ -740,6 +757,7 @@ class Layer(BaseObject):
 
         setters = (
             ('lib', set_attr),
+            ('tempLib', set_attr),
             ('color', set_attr),
             ('glyphs', set_glyphs)
         )

--- a/Lib/defcon/test/objects/test_font.py
+++ b/Lib/defcon/test/objects/test_font.py
@@ -788,5 +788,16 @@ class FontTest(unittest.TestCase):
         glyph.unicodes = [65]
         self.assertEqual(font.unicodeData[65], ["test", "A"])
 
+    def test_tempLib(self):
+        font = Font()
+
+        font.tempLib["foo"] = "bar"
+        self.assertEqual(font.tempLib, {"foo": "bar"})
+
+        otherFont = Font()
+        otherFont.setDataFromSerialization(font.getDataForSerialization())
+        self.assertEqual(otherFont.tempLib, {"foo": "bar"})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/defcon/test/objects/test_glyph.py
+++ b/Lib/defcon/test/objects/test_glyph.py
@@ -642,6 +642,17 @@ class GlyphTest(unittest.TestCase):
         pointPen.addComponent("baseGlyph", [1, 0, 0, 1, 0, 0])
         self.assertEqual(componentGlyph.area, 10000)
 
+    def test_tempLib(self):
+        font = Font()
+
+        glyph = font.newGlyph("A")
+        glyph.tempLib["foo"] = "bar"
+        self.assertEqual(glyph.tempLib, {"foo": "bar"})
+
+        otherGlyph = font.newGlyph("A.other")
+        otherGlyph.setDataFromSerialization(glyph.getDataForSerialization())
+        self.assertEqual(otherGlyph.tempLib, {"foo": "bar"})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/defcon/test/objects/test_image.py
+++ b/Lib/defcon/test/objects/test_image.py
@@ -39,6 +39,13 @@ class ImageTest(unittest.TestCase):
             (i.fileName, i.transformation, i.color),
             ('foo.png', ('1', '2', '3', '4', '5', '6'), '0,0,0,0'))
 
+    def test_clear(self):
+        i = Image()
+        i.fileName = "foo"
+        self.assertEqual(i.fileName, "foo")
+        i.clear()
+        self.assertIsNone(i.fileName)
+
     def test_read(self):
         font = Font(getTestFontPath())
         glyph = font.layers["Layer 1"]["A"]

--- a/Lib/defcon/test/objects/test_layer.py
+++ b/Lib/defcon/test/objects/test_layer.py
@@ -374,6 +374,16 @@ class LayerTest(unittest.TestCase):
         self.assertTrue(guideline.getParent(), insertedGlyph)
         self.assertTrue(guideline.dispatcher, newFont.dispatcher)
 
+    def test_tempLib(self):
+        font = Font()
+        layer = font.layers["public.default"]
+        layer.tempLib["foo"] = "bar"
+        self.assertEqual(layer.tempLib, {"foo": "bar"})
+
+        otherLayer = font.newLayer("other.layer")
+        otherLayer.setDataFromSerialization(layer.getDataForSerialization())
+        self.assertEqual(otherLayer.tempLib, {"foo": "bar"})
+
 
 class LayerWithTestFontCopyTest(unittest.TestCase):
 


### PR DESCRIPTION
`<font layer glyph>.tempLib` is a lib object to store lib data which is **not** saved into the ufo file, temporary data only available during the life span of the parent object.

Each object which has already an `lib` got a `tempLib`: `font`, `layer` and `glyph`