### PR TITLE
Add glyphSet argument in _stampLayerInfoDataState

### DIFF
--- a/Lib/defcon/objects/layerSet.py
+++ b/Lib/defcon/objects/layerSet.py
@@ -381,13 +381,15 @@ class LayerSet(BaseObject):
     # External Edit Support
     # ---------------------
 
-    def _stampLayerInfoDataState(self, layer):
-        if layer._glyphSet is None:
+    def _stampLayerInfoDataState(self, layer, glyphSet=None):
+        if glyphSet is None:
+            glyphSet = layer._glyphSet
+        if glyphSet is None:
             return
         # there isn't a mod time function
         # so load the data and pack it.
         i = _StaticLayerInfoMaker()
-        layer._glyphSet.readLayerInfo(i)
+        glyphSet.readLayerInfo(i)
         layer._dataOnDisk = i.pack()
 
     def testForExternalChanges(self, reader):


### PR DESCRIPTION
its possible the reader is already closed and similar to all other stamping callbacks a reader or glyphSet could optionally be provided