### PR TITLE
Do not create empty guidelines array

### DIFF
--- a/Lib/defcon/objects/font.py
+++ b/Lib/defcon/objects/font.py
@@ -1060,6 +1060,8 @@ class Font(BaseObject):
     def _get_guidelines(self):
         if self._info is None:
             self.info
+        if not self._guidelines:
+            return None
         return list(self._guidelines)
 
     def _set_guidelines(self, value):


### PR DESCRIPTION
Before this change, any f.save() would create an empty guidelines array in the fontinfo.plist.
Since guidelines are an optinal attribute, I do not think this is necessary.