### PR TITLE
Mark regex/docstring as raw to fix SyntaxWarning invalid escape seq

### DIFF
--- a/Lib/defcon/objects/base.py
+++ b/Lib/defcon/objects/base.py
@@ -334,7 +334,7 @@ class BaseObject(object):
     # ---------------
 
     def getRepresentation(self, name, **kwargs):
-        """
+        r"""
         Get a representation. **name** must be a registered
         representation name. **\*\*kwargs** will be passed
         to the appropriate representation factory.
@@ -357,7 +357,7 @@ class BaseObject(object):
             return representations[subKey]
 
     def destroyRepresentation(self, name, **kwargs):
-        """
+        r"""
         Destroy the stored representation for **name**
         and **\*\*kwargs**. If no **kwargs** are given,
         any representation with **name** will be destroyed
@@ -402,7 +402,7 @@ class BaseObject(object):
         return representations
 
     def hasCachedRepresentation(self, name, **kwargs):
-        """
+        r"""
         Returns a boolean indicating if a representation for
         **name** and **\*\*kwargs** is cached in the object.
         """

--- a/Lib/defcon/objects/font.py
+++ b/Lib/defcon/objects/font.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 class Font(BaseObject):
 
-    """
+    r"""
     If loading from an existing UFO, **path** should be the path to the UFO.
 
     If you subclass one of the sub objects, such as :class:`Glyph`,
@@ -1647,13 +1647,13 @@ class Font(BaseObject):
                     setattr(self.info, infoAttr, value)
 
     featureRE = re.compile(
-        "^"            # start of line
-        "\s*"          #
-        "feature"      # feature
-        "\s+"          #
-        "(\w{4})"      # four alphanumeric characters
-        "\s*"          #
-        "\{"           # {
+        r"^"           # start of line
+        r"\s*"         #
+        r"feature"     # feature
+        r"\s+"         #
+        r"(\w{4})"     # four alphanumeric characters
+        r"\s*"         #
+        r"\{"          # {
         , re.MULTILINE # run in multiline to preserve line seps
     )
 

--- a/Lib/defcon/test/objects/test_kerning.py
+++ b/Lib/defcon/test/objects/test_kerning.py
@@ -38,7 +38,7 @@ class KerningTest(unittest.TestCase):
     def test___getitem__(self):
         font = Font(getTestFontPath())
         self.assertEqual(font.kerning["A", "A"], -100)
-        with self.assertRaisesRegex(KeyError, "\('NotInFont', 'NotInFont'\)"):
+        with self.assertRaisesRegex(KeyError, r"\('NotInFont', 'NotInFont'\)"):
             font.kerning["NotInFont", "NotInFont"]
 
     def test___setitem__(self):


### PR DESCRIPTION
See https://github.com/robotools/defcon/issues/454 and https://bugs.debian.org/1068525 for details.

closes: #454