### PR TITLE
Remove a useless shebang line in a non-executable test script

### DIFF
--- a/Lib/defcon/test/tools/test_unicodeTools.py
+++ b/Lib/defcon/test/tools/test_unicodeTools.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import unittest


### PR DESCRIPTION
This file does not have executable filesystem permissions, and it does not have script-like content (no `if __name__ == "__main__":` or interesting side-effects).