### PR TITLE
Loop over all possibilities and test if one of them is disabled

### DIFF
--- a/Lib/defcon/tools/notifications.py
+++ b/Lib/defcon/tools/notifications.py
@@ -181,6 +181,7 @@ class NotificationCenter(object):
             for key in holdDisabledPossibilities:
                 if key in self._disabled:
                     return
+            for key in holdDisabledPossibilities:
                 if key in self._holds:
                     n = (notification, observableRef, data)
                     if n not in self._holds[key]["notifications"]:


### PR DESCRIPTION
@typesupply please test before merging...

```py
import defcon 

f = defcon.Font()

names = ["A"]

f.dispatcher.holdNotifications()
for name in names:
    f.newGlyph(name) 

f.dispatcher.releaseHeldNotifications()
```

this script throws an error: `defcon/objects/layer.py", line 707, in _glyphNameChange
KeyError: None`

* `layer.newGlyph* [disables all notifications](https://github.com/robotools/defcon/blob/923bd190d85ac3b40915db7dd8b8e1569c4b6771/Lib/defcon/objects/layer.py#L193)
* when looping over all held notifications the disabled one is still there...

--> first loop over all possible combinations and test it against the disabled notifications, if found just return, otherwise look to store them in the held notifications

