### PR TITLE
simplify use of pyfilesystem2 API in test suite

### DIFF
--- a/Lib/defcon/test/objects/test_dataSet.py
+++ b/Lib/defcon/test/objects/test_dataSet.py
@@ -122,8 +122,7 @@ class DataSetTest(unittest.TestCase):
                 # image = font.data["com.typesupply.defcon.test.file"]
                 font.data["com.typesupply.defcon.test.file"]
                 fileSystem = openTestFontAsFileSystem(font.path)
-                fileSystem.remove(fs.path.join("data",
-                                       "com.typesupply.defcon.test.file"))
+                fileSystem.remove("data/com.typesupply.defcon.test.file")
                 closeTestFontAsFileSystem(fileSystem, font.path)
                 with UFOReader(path) as reader:
                     self.assertEqual(font.data.testForExternalChanges(reader),
@@ -136,8 +135,8 @@ class DataSetTest(unittest.TestCase):
             path = makeTestFontCopy(path)
             with Font(path) as font:
                 fileSystem = openTestFontAsFileSystem(font.path)
-                source = fs.path.join("data", "com.typesupply.defcon.test.file")
-                dest = fs.path.join("data", "com.typesupply.defcon.test.file2")
+                source = "data/com.typesupply.defcon.test.file"
+                dest = "data/com.typesupply.defcon.test.file2"
                 fileSystem.copy(source, dest)
                 closeTestFontAsFileSystem(fileSystem, font.path)
                 with UFOReader(path) as reader:
@@ -153,8 +152,7 @@ class DataSetTest(unittest.TestCase):
                 # d = font.data["com.typesupply.defcon.test.file"]
                 font.data["com.typesupply.defcon.test.file"]
                 fileSystem = openTestFontAsFileSystem(font.path)
-                filePath = fs.path.join("data",
-                                        "com.typesupply.defcon.test.file")
+                filePath = "data/com.typesupply.defcon.test.file"
                 fileSystem.writebytes(filePath, b"blah")
                 closeTestFontAsFileSystem(fileSystem, font.path)
                 with UFOReader(path) as reader:

--- a/Lib/defcon/test/objects/test_font.py
+++ b/Lib/defcon/test/objects/test_font.py
@@ -126,9 +126,9 @@ class FontTest(unittest.TestCase):
             with Font(path) as font:
                 font["A"]  # glyph = font["A"]
                 fileSystem = openTestFontAsFileSystem(path)
-                glyphPath = fs.path.join("glyphs", "A_.glif")
+                glyphPath = "glyphs/A_.glif"
                 fileSystem.remove(glyphPath)
-                contentsPath = fs.path.join("glyphs", "contents.plist")
+                contentsPath = "glyphs/contents.plist"
                 with fileSystem.open(contentsPath, "rb") as f:
                     plist = load(f)
                 del plist["A"]
@@ -150,9 +150,9 @@ class FontTest(unittest.TestCase):
                 glyph = font["A"]
                 glyph.dirty = True
                 fileSystem = openTestFontAsFileSystem(path)
-                glyphPath = fs.path.join("glyphs", "A_.glif")
+                glyphPath = "glyphs/A_.glif"
                 fileSystem.remove(glyphPath)
-                contentsPath = fs.path.join("glyphs", "contents.plist")
+                contentsPath = "glyphs/contents.plist"
                 with fileSystem.open(contentsPath, "rb") as f:
                     plist = load(f)
                 del plist["A"]
@@ -426,8 +426,9 @@ class FontTest(unittest.TestCase):
                     font.save()
                     fileNames = sorted(
                         [
-                            fs.path.basename(m.path)
-                            for m in UFOReader(path).fs.glob("glyphs/*.glif")
+                            path
+                            for path in UFOReader(path).fs.listdir("glyphs")
+                            if path.endswith(".glif")
                         ]
                     )
                     self.assertEqual(fileNames, ["A_.glif", "B_.glif", "C_.glif"])
@@ -446,8 +447,9 @@ class FontTest(unittest.TestCase):
             try:
                 fileNames = sorted(
                     [
-                        fs.path.basename(m.path)
-                        for m in UFOReader(saveAsPath).fs.glob("glyphs/*.glif")
+                        path
+                        for path in UFOReader(saveAsPath).fs.listdir("glyphs")
+                        if path.endswith(".glif")
                     ]
                 )
                 self.assertEqual(fileNames, ["A_.glif", "B_.glif", "C_.glif"])
@@ -518,8 +520,9 @@ class FontTest(unittest.TestCase):
             self.assertEqual(font.ufoFileStructure, UFOFileStructure.ZIP)
             fileNames = sorted(
                 [
-                    fs.path.basename(m.path)
-                    for m in UFOReader(dest).fs.glob("glyphs/*.glif")
+                    path
+                    for path in UFOReader(dest).fs.listdir("glyphs")
+                    if path.endswith(".glif")
                 ]
             )
             self.assertEqual(fileNames, ["A_.glif", "B_.glif", "C_.glif"])

--- a/Lib/defcon/test/objects/test_imageSet.py
+++ b/Lib/defcon/test/objects/test_imageSet.py
@@ -133,7 +133,7 @@ class ImageSetTest(unittest.TestCase):
             path = makeTestFontCopy(path)
             with Font(path) as font:
                 fileSystem = openTestFontAsFileSystem(font.path)
-                fileSystem.remove(fs.path.join("images", "image 1.png"))
+                fileSystem.remove("images/image 1.png")
                 closeTestFontAsFileSystem(fileSystem, font.path)
                 with UFOReader(path) as reader:
                     self.assertEqual(font.images.testForExternalChanges(reader),
@@ -146,9 +146,7 @@ class ImageSetTest(unittest.TestCase):
             path = makeTestFontCopy(path)
             with Font(path) as font:
                 fileSystem = openTestFontAsFileSystem(font.path)
-                source = fs.path.join("images", "image 1.png")
-                dest = fs.path.join("images", "image 3.png")
-                fileSystem.copy(source, dest)
+                fileSystem.copy("images/image 1.png", "images/image 3.png")
                 closeTestFontAsFileSystem(fileSystem, font.path)
                 with UFOReader(path) as reader:
                     self.assertEqual(font.images.testForExternalChanges(reader),
@@ -162,7 +160,7 @@ class ImageSetTest(unittest.TestCase):
             with Font(path) as font:
                 font.images["image 1.png"]  # image = font.images["image 1.png"]
                 fileSystem = openTestFontAsFileSystem(font.path)
-                imagePath = fs.path.join("images", "image 1.png")
+                imagePath = "images/image 1.png"
                 data = fileSystem.readbytes(imagePath)
                 fileSystem.writebytes(imagePath, data + b"blah")
                 closeTestFontAsFileSystem(fileSystem, font.path)

--- a/Lib/defcon/test/objects/test_layer.py
+++ b/Lib/defcon/test/objects/test_layer.py
@@ -189,7 +189,7 @@ class LayerTest(unittest.TestCase):
                         # make a simple change to a glyph
                         fileSystem = openTestFontAsFileSystem(font.path)
                         g = font.layers[None]["A"]
-                        path = fs.path.join("glyphs", "A_.glif")
+                        path = "glyphs/A_.glif"
                         t = fileSystem.readbytes(path)
                         t += b"<!-- test -->"
                         fileSystem.writebytes(path, t)
@@ -208,13 +208,13 @@ class LayerTest(unittest.TestCase):
 
                     # add a glyph
                     fileSystem = openTestFontAsFileSystem(font.path)
-                    path = fs.path.join("glyphs", "A_.glif")
+                    path = "glyphs/A_.glif"
                     t = fileSystem.readbytes(path)
                     t = t.replace(b'<glyph name="A" format="1">',
                                   b'<glyph name="XYZ" format="1">')
-                    path = fs.path.join("glyphs", "XYZ.glif")
+                    path = "glyphs/XYZ.glif"
                     fileSystem.writebytes(path, t)
-                    path = fs.path.join("glyphs", "contents.plist")
+                    path = "glyphs/contents.plist"
                     with fileSystem.open(path, "rb") as f:
                         plist = load(f)
                     savePlist = dict(plist)
@@ -231,10 +231,10 @@ class LayerTest(unittest.TestCase):
                 with Font(path) as font:
                     g = font["XYZ"]
                     fileSystem = openTestFontAsFileSystem(font.path)
-                    path = fs.path.join("glyphs", "contents.plist")
+                    path = "glyphs/contents.plist"
                     with fileSystem.open(path, "wb") as f:
                         dump(savePlist, f)
-                    path = fs.path.join("glyphs", "XYZ.glif")
+                    path = "glyphs/XYZ.glif"
                     fileSystem.remove(path)
                     closeTestFontAsFileSystem(fileSystem, font.path)
                     with UFOReader(font.path) as reader:

--- a/Lib/defcon/test/objects/test_layerSet.py
+++ b/Lib/defcon/test/objects/test_layerSet.py
@@ -134,8 +134,7 @@ class LayerTest(unittest.TestCase):
                 data = {"lib": {}}
                 data["lib"]["testForExternalChanges.test"] = 1
                 fileSystem = openTestFontAsFileSystem(path)
-                p = fs.path.join("glyphs", "layerinfo.plist")
-                with fileSystem.open(p, mode="wb") as f:
+                with fileSystem.open("glyphs/layerinfo.plist", mode="wb") as f:
                     dump(data, f)
                 closeTestFontAsFileSystem(fileSystem, path)
                 with UFOReader(path) as reader:


### PR DESCRIPTION
we are planning on dropping a hard dependency on `fs` module (pyfilesystem2) in fontTools.ufoLib since it is no longer maintained and is starting to issue a bunch of deprecation warnings (e.g. from pkg_resources scheduled for removal from setuptools in a few months).
I worked on writing a stdlib-only replacement for the subset of classes/functions that ufoLib is currently using here: 
https://github.com/fonttools/fonttools/pull/3885
If one does have `fs` installed, it will still be used for as long as it continues to work (like a "soft" or optional dependency).

Now I noticed defcon's own test suite imports from and calls `fs` methods directly in a bunch of places, that's ok.
However, no matter wheter one is using `fs` directly or its fallback replacement in `fontTools.misc.filesytem`, there are a few things that defcon's tests can do to simplify things a bit:

1) calls to `fs.path.join` are unneeded, since what they do is basically just join with a UNIX-style forward slash `"f{path1}/{path2}"`; unlike `os.path.join` all the paths used by pyfilesystem2 internally are supposed to use forward slashes no matter the platform, so `fs.path.join` is not actually needed given defcon is passing it plain string literals without any '..' backreferences etc. Incidentally, I have one fewer function to port over to `fontTools.misc.filesytem` :)

2) some tests use `FS.glob()` method to list all the `"glyphs/*.glif"` files, but the same can be achieved with `listdir()` and filtering results by whether endswith(".glif"). Again, implementing glob method properly in fontTools is too much work for not much gain...

After these changes, one can in theory replace all the direct `import fs` with a `import fontTools.misc.filesystem as fs` and everything works whether or not `fs` is actually installed.