### PR TITLE
Use trusted publishing

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -23,6 +23,11 @@ jobs:
   deploy:
 
     runs-on: ubuntu-latest
+    environment:
+      name: publish-to-pypi
+      url: https://pypi.org/p/defcon
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
 
     steps:
     - uses: actions/checkout@v4.2.2
@@ -38,7 +43,4 @@ jobs:
       run: |
         python setup.py sdist bdist_wheel
     - name: Publish
-      uses: pypa/gh-action-pypi-publish@v1.12.4
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_PASSWORD }}
+      uses: pypa/gh-action-pypi-publish@v1.13.0


### PR DESCRIPTION
In light of the recent npm supply chain attacks and also https://blog.pypi.org/posts/2025-09-16-github-actions-token-exfiltration/, I'm combing through our font stack to see if all them Py projects are using the trusted publisher mechanism as recommended by PyPI. See https://docs.pypi.org/trusted-publishers/ and https://docs.astral.sh/uv/guides/integration/github/#publishing-to-pypi.

Someone needs to do three things for this PR to work:

* Create an environment called "publish-to-pypi" in this GitHub repository under Settings -> Environments. Creating alone is probably enough, no configuration needed I think.
* Follow https://docs.pypi.org/trusted-publishers/adding-a-publisher/ to set up the other side on PyPI.
* Remove tokens/secret variables here so they can't be exfiltrated anymore, and probably also remove them from PyPI.
