### PR TITLE
Use sets to optimize ordered Unicode collections

### DIFF
--- a/Lib/defcon/tools/unicodeTools.py
+++ b/Lib/defcon/tools/unicodeTools.py
@@ -298,19 +298,23 @@ for line in _openClosePairText.splitlines():
 
 # ordered sets
 orderedScripts = []
+seen_scripts = set()
 for value in unicodedata.Scripts.VALUES:
     value = unicodedata.script_name(value)
     if value == "Unknown":
         continue
-    if value not in orderedScripts:
+    if value not in seen_scripts:
+        seen_scripts.add(value)
         orderedScripts.append(value)
 orderedScripts.append("Unknown")
 
 orderedBlocks = []
+seen_blocks = set()
 for value in unicodedata.Blocks.VALUES:
     if value == "No_Block":
         continue
-    if value not in orderedBlocks:
+    if value not in seen_blocks:
+        seen_blocks.add(value)
         orderedBlocks.append(value)
 
 orderedCategories = """Lu


### PR DESCRIPTION
Hi! First of all, thanks for the great work on this project.

I noticed that the construction of `orderedScripts` and `orderedBlocks` currently relies on checking membership in lists:

```python3
value not in orderedScripts  
value not in orderedBlocks  
```

This results in an O(N) lookup for each iteration, making the overall process more expensive as the lists grow. The logic is correct and clear, but the membership check itself can be optimized.

To keep the same behavior while improving performance, this PR introduces auxiliary sets:
```python3
seen_scripts = set()  
seen_blocks = set()  
```
These sets are used only to track which values were already added, while the lists are still responsible for preserving order.

With this change:
- The membership test goes from O(N) to O(1) on average  
- The ordered lists keep exactly the same output  
- The intent becomes clearer: sets for fast lookup, lists for ordering  

It’s a small and safe change, but it improves efficiency and makes the logic a bit more explicit.